### PR TITLE
[BAC 160] - cleanup namespaces in templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
 
+eventrouter/Chart.yaml

--- a/eventrouter/templates/configmap.yaml
+++ b/eventrouter/templates/configmap.yaml
@@ -8,3 +8,8 @@ data:
 kind: ConfigMap
 metadata:
   name: {{ .Values.name }}-configmap
+  labels:
+    app: {{ template "name" . }}
+    chart: "{{.Chart.Name}}-{{.Chart.Version}}"
+    release: "{{.Release.Name}}"
+    heritage: "{{.Release.Service}}"

--- a/eventrouter/templates/configmap.yaml
+++ b/eventrouter/templates/configmap.yaml
@@ -8,4 +8,3 @@ data:
 kind: ConfigMap
 metadata:
   name: {{ .Values.name }}-configmap
-  namespace: {{ .Values.namespace }} 

--- a/eventrouter/templates/deployment.yaml
+++ b/eventrouter/templates/deployment.yaml
@@ -3,7 +3,6 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: {{ .Values.name }}
-  namespace: {{ .Values.namespace }}
 spec:
   replicas: {{ .Values.replicaCount }}
   template:

--- a/eventrouter/templates/deployment.yaml
+++ b/eventrouter/templates/deployment.yaml
@@ -3,6 +3,11 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: {{ .Values.name }}
+  labels:
+    app: {{ template "name" . }}
+    chart: "{{.Chart.Name}}-{{.Chart.Version}}"
+    release: "{{.Release.Name}}"
+    heritage: "{{.Release.Service}}"
 spec:
   replicas: {{ .Values.replicaCount }}
   template:

--- a/eventrouter/templates/rbac.yaml
+++ b/eventrouter/templates/rbac.yaml
@@ -3,7 +3,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ .Values.name }} 
-  namespace: {{ .Values.namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -25,4 +24,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ .Values.name }}
-  namespace: {{ .Values.namespace }}
+  namespace: {{.Release.Namespace}}

--- a/eventrouter/templates/rbac.yaml
+++ b/eventrouter/templates/rbac.yaml
@@ -3,11 +3,21 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ .Values.name }} 
+  labels:
+    app: {{ template "name" . }}
+    chart: "{{.Chart.Name}}-{{.Chart.Version}}"
+    release: "{{.Release.Name}}"
+    heritage: "{{.Release.Service}}"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ .Values.name }} 
+  labels:
+    app: {{ template "name" . }}
+    chart: "{{.Chart.Name}}-{{.Chart.Version}}"
+    release: "{{.Release.Name}}"
+    heritage: "{{.Release.Service}}"
 rules:
 - apiGroups: [""]
   resources: ["events"]
@@ -17,6 +27,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ .Values.name }} 
+  labels:
+    app: {{ template "name" . }}
+    chart: "{{.Chart.Name}}-{{.Chart.Version}}"
+    release: "{{.Release.Name}}"
+    heritage: "{{.Release.Service}}"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/eventrouter/values.yaml
+++ b/eventrouter/values.yaml
@@ -1,5 +1,4 @@
 name: "eventrouter"
-namespace: "default"
 replicaCount: 1
 image:
   repository: "quay.io/samsung_cnct/eventrouter-container"


### PR DESCRIPTION
**What this PR does / why we need it**: This PR removes the explicitly created namespace template value in favor of the helm provided namespace. This should be set on the helm install command. Additionally the templates can refer to `{{.Release.Namespace}}` when explicitly needed. Such as the ClusterRoleBinding resource.

**Which issue this PR fixes**:
This is part of [BAC-160][160]

**Verification Notes**:

To verify this you can install this chart into a dev cluster:
```
CHART_NAME=eventrouter build/build.sh
helm install --name eventrouter-0 --namespace eventrouter-test ./eventrouter
kubectl -n eventrouter-test get all
helm status eventrouter-0
```

[160]: https://samsung-cnct.atlassian.net/browse/BAC-160