### PR TITLE
no functional change, but this prevents future errors

### DIFF
--- a/charts/eventrouter/templates/rbac-clusterrole.yaml
+++ b/charts/eventrouter/templates/rbac-clusterrole.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ .Values.name }}-{{ .Release.Namespace }}
+  name: "{{ template "uniqName" . }}"
   labels:
     app: {{ template "eventrouter.name" . }}
     chart: {{ template "namewithversion" . }}


### PR DESCRIPTION
uniqName is defined as ".Chart.Name-.Release.Namespace" so same
output but now if somsone changes uniqName the permissions still
work