### PR TITLE
preserve time value

### DIFF
--- a/charts/eventrouter/templates/tests/01-eventrouter-event-send-recv.yaml
+++ b/charts/eventrouter/templates/tests/01-eventrouter-event-send-recv.yaml
@@ -83,14 +83,19 @@ data:
     BATS_TMPDIR="/testfiles"
     TEST_TMPL="$TEST_TMPL_DIR/event-test.tpl"
     TEST_JSON="$TEST_TEMP_DIR/tests.json"
+    TEST_DATE="$TEST_TEMP_DIR/date.txt"
     TMP_RESP="$BATS_TMPDIR/resp.out"
-    TIMESTAMP="$(date +%FT%H:%M:%SZ)"
-
+    
     # TIMENOW is set in the pod definition
     cd $TEST_TMPL_DIR
 
     # test 1
     @test "Create VALID test JSON from template" {
+      # NOTE: env vars get re-eval'd on every @test step...so theis value changes
+      # hack to save the exact time until the next steps...
+      TIMESTAMP="$(date +%FT%H:%M:%SZ)"
+      echo "$TIMESTAMP" > $TEST_DATE
+
       echo "" >&3
       echo "=====================================" >&3
       echo "\$TIMENOW is: $TIMENOW" >&3
@@ -154,6 +159,7 @@ data:
 
     # test 3
     @test "Test VERIFY event to EventRouter Service RECVd" {
+      TIMESTAMP="$(cat $TEST_DATE)"
       # sleep for a little to make sure it gets written
       ATTEMPTS=1
       RESP=0


### PR DESCRIPTION
fixes flakey test issuses
Each bats test step re-evaluates the env vars...this causes the TIMESTAMP to be reset..which then causes the test to fail.